### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,14 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
-
-sudo: required
+  - 7.2
+  - 7.3
 
 install: composer install
 
-before_script:
-  # navigate out of module directory to prevent blown stack by recursive module lookup
-  - wget https://phar.phpunit.de/phpunit.phar
-  - chmod +x phpunit.phar
-  - sudo mv phpunit.phar /usr/local/bin/phpunit
-  - phpunit --version
-
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install
-  - php composer.phar require satooshi/php-coveralls
-
 script:
   - mkdir -p build/logs
-  - phpunit -c phpunit.xml.dist
+  - vendor/bin/phpunit -c phpunit.xml.dist
 
 after_script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then travis_retry php vendor/bin/coveralls -v; fi

--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,17 @@
         "psr/cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.6.*"
+        "phpunit/phpunit": "^5.6",
+        "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
         "psr-4": {
-            "TinyCache\\": ["src/","tests/"]
-        },
-        "files": [
-        ]
+            "TinyCache\\": "src/"
+        }
     },
     "autoload-dev": {
         "psr-4": {
-            "TinyCache\\": ["src/","tests/"]
+            "TinyCache\\": "tests/"
         }
     },
     "extra": {

--- a/tests/Adapter/FilesystemAdapterTest.php
+++ b/tests/Adapter/FilesystemAdapterTest.php
@@ -15,14 +15,21 @@ use TinyCache\Adapter\FilesystemAdapter;
 
 class FilesystemAdapterTest extends TestCase
 {
+    protected $dir;
+
+    protected function setUp()
+    {
+        if (file_exists($this->dir)) {
+            @rmdir($this->dir);
+        }
+    }
+
     public function testFilesystemAdapter()
     {
-        $dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'tiny-cache';
-        if (file_exists($dir)) {
-            @rmdir($dir);
-        }
+        $this->dir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'tiny-cache';
+
         $adapter = new FilesystemAdapter();
-        $this->assertInstanceOf('TinyCache\Adapter\FilesystemAdapter', $adapter);
+        $this->assertInstanceOf(FilesystemAdapter::class, $adapter);
 
         $item1 = new Item('hi1', 'Hola');
         $item2 = new Item('hi2', 'Hola');
@@ -36,10 +43,10 @@ class FilesystemAdapterTest extends TestCase
         $adapter->save($item3);
 
         $items = $adapter->getItems(['hi1', 'hi2']);
-        $this->assertInstanceOf('TinyCache\Collection', $items);
+        $this->assertInstanceOf(Collection::class, $items);
 
         $getItem = $adapter->getItem('hi1');
-        $this->assertInstanceOf('TinyCache\Item', $getItem);
+        $this->assertInstanceOf(Item::class, $getItem);
         $getItem = $adapter->getItem('hi');
 
         $adapter->hasItem('hi1');

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -18,16 +18,16 @@ class CacheTest extends TestCase
     public function testTinyCache()
     {
         $adapter = new FilesystemAdapter();
-        $this->assertInstanceOf('TinyCache\Adapter\FilesystemAdapter', $adapter);
+        $this->assertInstanceOf(FilesystemAdapter::class, $adapter);
 
         $cache = new Cache($adapter);
-        $this->assertInstanceOf('TinyCache\Cache', $cache);
+        $this->assertInstanceOf(Cache::class, $cache);
 
         $item1 = new Item('hi1', 'Hola');
-        $this->assertInstanceOf('TinyCache\Item', $item1);
+        $this->assertInstanceOf(Item::class, $item1);
 
         $item2 = new Item('hi2', 'Hola');
-        $this->assertInstanceOf('TinyCache\Item', $item2);
+        $this->assertInstanceOf(Item::class, $item2);
 
         $cache->saveDeferred($item1);
 
@@ -36,10 +36,10 @@ class CacheTest extends TestCase
         $cache->save($item2);
 
         $items = $cache->getItems(['hi1', 'hi2']);
-        $this->assertInstanceOf('TinyCache\Collection', $items);
+        $this->assertInstanceOf(Collection::class, $items);
 
         $getItem = $cache->getItem('hi1');
-        $this->assertInstanceOf('TinyCache\Item', $getItem);
+        $this->assertInstanceOf(Item::class, $getItem);
 
         $cache->hasItem('hi1');
         $cache->deleteItem('hi1');

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -10,6 +10,7 @@
 
 namespace TinyCache;
 
+use ArrayIterator;
 use PHPUnit\Framework\TestCase;
 
 class CollectionTest extends TestCase
@@ -17,7 +18,7 @@ class CollectionTest extends TestCase
     public function testCollection()
     {
         $collection = new Collection(['key'=>'value']);
-        $this->assertInstanceOf('TinyCache\Collection', $collection);
+        $this->assertInstanceOf(Collection::class, $collection);
 
         $value = $collection->get('key');
         $this->assertSame('value', $value);
@@ -34,7 +35,7 @@ class CollectionTest extends TestCase
         $this->assertSame(1, $one);
 
         $iterator = $collection->getIterator();
-        $this->assertInstanceOf('ArrayIterator', $iterator);
+        $this->assertInstanceOf(ArrayIterator::class, $iterator);
 
         $collection->offsetUnset('key');
         $collection->clear();

--- a/tests/HashTest.php
+++ b/tests/HashTest.php
@@ -14,19 +14,49 @@ use PHPUnit\Framework\TestCase;
 
 class HashTest extends TestCase
 {
-    public function testHash()
+    protected $file;
+
+    /**
+     * @dataProvider providerFileSha1
+     */
+    public function testFileSha1($contents, $expected)
     {
-        $hash = Hash::string('hola');
-        $hash = Hash::css('<p>Hola</p>');
-        $hash = Hash::html('.hola{}');
-
         $dir = sys_get_temp_dir();
-        $file = $dir.DIRECTORY_SEPARATOR.'hola.txt';
+        $this->file = $dir.DIRECTORY_SEPARATOR.'hola.txt';
 
-        file_put_contents($dir.DIRECTORY_SEPARATOR.'hola.txt', 'hola');
+        file_put_contents($dir.DIRECTORY_SEPARATOR.'hola.txt', $contents);
 
         $hash = Hash::fileSha1($dir.DIRECTORY_SEPARATOR.'hola.txt');
 
-        @unlink($file);
+        $this->assertSame($hash, $expected);
+    }
+
+    public function providerFileSha1()
+    {
+        return [
+            ['hola', '99800b85d3383e3a2fb45eb7d0066a4879a9dad0'],
+            ['<p>Hola</p>', '253629c104c29914e69213ba58318a0de1ea51e7'],
+            ['.hola{}', '62a23c48400389fc01d912381a01eb84265cfd36'],
+        ];
+    }
+
+    public function testString()
+    {
+        $this->assertSame('99800b85d3383e3a2fb45eb7d0066a4879a9dad0', Hash::string('hola'));
+    }
+
+    public function testHtml()
+    {
+        $this->assertSame('253629c104c29914e69213ba58318a0de1ea51e7', Hash::html('<p>Hola</p>'));
+    }
+
+    public function testCss()
+    {
+        $this->assertSame('62a23c48400389fc01d912381a01eb84265cfd36', Hash::css('.hola{}'));
+    }
+
+    protected function tearDown()
+    {
+        @unlink($this->file);
     }
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -17,7 +17,7 @@ class ItemTest extends TestCase
     public function testItem()
     {
         $item = new Item('key1', 'Hola');
-        $this->assertInstanceOf('TinyCache\Item', $item);
+        $this->assertInstanceOf(Item::class, $item);
 
         $key = $item->getKey();
         $this->assertSame('key1', $key);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * TinyCache.
  *
- * @link      https://github.com/adrorocker/php-firebase
+ * @link      https://github.com/adrorocker/tiny-cache
  *
  * @copyright Copyright (c) 2017 Adro Rocker
  * @author    Adro Rocker <alejandro.morelos@jarwebdev.com>


### PR DESCRIPTION
# Changed log
- Using the `::class` syntax to assert the expected instance name is same as result.
- Remove `sudo: required` setting and using the default `composer` and `vendor/bin/phpunit` commands.
- Correct the `Hash` class tests.
- The `php-7.2` and `php-7.3` versions are released, and `HHVM` will not be compatible with `php-7.x` versions in the future.
I think it's fine to remove `HHVM` version test during Travis CI build.